### PR TITLE
Update makefile to make more portable

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -10,6 +10,7 @@ ifeq ($(UNAME_S),Darwin)
 	LDLIBS+=-lomp
 else
 	CXXFLAGS=-fopenmp
+	LDFLAGS+=-fopenmp
 endif
 
 SuSiEx: main.cpp data.o model.o

--- a/src/makefile
+++ b/src/makefile
@@ -1,14 +1,27 @@
+CXXFLAGS=-O3 -Wall -Wextra
+LDFLAGS=-O3 -flto
+
 all: SuSiEx
+
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	CXXFLAGS+=-Xpreprocessor -fopenmp
+	LDLIBS+=-lomp
+else
+	CXXFLAGS=-fopenmp
+endif
 
 SuSiEx: main.cpp data.o model.o
 	mkdir -p ../bin
-	g++ main.cpp data.o model.o -O3 -o ../bin/SuSiEx -fopenmp
+	$(CXX) $(LDFLAGS) main.cpp data.o model.o -o ../bin/SuSiEx $(LDLIBS)
 
 data.o: data.cpp data.hpp
-	g++ -c data.cpp -fopenmp
+	$(CXX) $(CXXFLAGS) -c data.cpp
 
 model.o: model.cpp model.hpp
-	g++ -c model.cpp -fopenmp
+	$(CXX) $(CXXFLAGS) -c model.cpp
 
+.PHONY: clean
 clean:
 	rm -rf *.o ../bin/SuSiEx

--- a/src/makefile
+++ b/src/makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-O3 -Wall -Wextra
+CXXFLAGS=-O3 -Wall -Wextra -flto
 LDFLAGS=-O3 -flto
 
 all: SuSiEx


### PR DESCRIPTION
Update makefile to work with Apple Clang on Mac OS, and to follow Makefile norms more closely.

I did this while packaging SuSiEx for bioconda, my group has been using it and it'd be nice if it were available to install through Bioconda: https://github.com/bioconda/bioconda-recipes/pull/44131

This Makefile should be more flexible and portable for anyone to be able to work with SuSiEx in the future.

I also noticed that the previous makefile didn't apply optimizations at all, you have to tell the compilation step -O3 and it was only being applied at the linking step.